### PR TITLE
modify long to bytes with benchmarks

### DIFF
--- a/netty-socketio-core/src/test/java/com/corundumstudio/socketio/benchmark/LongToBytesBenchmark.java
+++ b/netty-socketio-core/src/test/java/com/corundumstudio/socketio/benchmark/LongToBytesBenchmark.java
@@ -15,28 +15,37 @@
  */
 package com.corundumstudio.socketio.benchmark;
 
-import org.openjdk.jmh.annotations.*;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-
-import java.util.concurrent.TimeUnit;
 
 import com.corundumstudio.socketio.protocol.PacketEncoder;
 
 /**
  * JMH Benchmark for longToBytes performance comparison
  */
-@BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 public class LongToBytesBenchmark {
 
-    @Param({"0", "1", "123", "12345", "123456789", "1234567890123456"})
+    @Param({"0", "1", "123", "12345", "123456789", "1760666224123"})
     public long testValue;
 
     /**


### PR DESCRIPTION
Result:

```
Benchmark                               (testValue)   Mode  Cnt       Score       Error   Units
LongToBytesBenchmark.optimizedMethod              0  thrpt    5  341953.998 ±  1290.600  ops/ms
LongToBytesBenchmark.optimizedMethod              1  thrpt    5  494923.006 ± 14451.153  ops/ms
LongToBytesBenchmark.optimizedMethod            123  thrpt    5  246779.726 ±  3226.868  ops/ms
LongToBytesBenchmark.optimizedMethod          12345  thrpt    5  173904.831 ±  1019.761  ops/ms
LongToBytesBenchmark.optimizedMethod      123456789  thrpt    5   93918.635 ±   408.958  ops/ms
LongToBytesBenchmark.optimizedMethod  1760666224123  thrpt    5   61634.305 ±   516.401  ops/ms
LongToBytesBenchmark.originalMethod               0  thrpt    5  340011.077 ±  1307.073  ops/ms
LongToBytesBenchmark.originalMethod               1  thrpt    5  219453.469 ± 12794.860  ops/ms
LongToBytesBenchmark.originalMethod             123  thrpt    5   85637.985 ±  1450.208  ops/ms
LongToBytesBenchmark.originalMethod           12345  thrpt    5   90153.533 ±  1232.794  ops/ms
LongToBytesBenchmark.originalMethod       123456789  thrpt    5   69504.474 ±   502.885  ops/ms
LongToBytesBenchmark.originalMethod   1760666224123  thrpt    5   57477.330 ±   917.341  ops/ms
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated benchmark test configurations to enhance performance measurement accuracy and refine test parameters for improved system behavior evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->