### PR TITLE
Add io_uring support for Linux native transport

### DIFF
--- a/netty-socketio-core/pom.xml
+++ b/netty-socketio-core/pom.xml
@@ -43,6 +43,11 @@
       <artifactId>netty-transport-native-epoll</artifactId>
       <scope>provided</scope>
     </dependency>
+      <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-io_uring</artifactId>
+          <scope>provided</scope>
+      </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/netty-socketio-core/src/main/java/com/corundumstudio/socketio/BasicConfiguration.java
+++ b/netty-socketio-core/src/main/java/com/corundumstudio/socketio/BasicConfiguration.java
@@ -31,6 +31,7 @@ public abstract class BasicConfiguration {
     protected int bossThreads = 0; // 0 = current_processors_amount * 2
     protected int workerThreads = 0; // 0 = current_processors_amount * 2
     protected boolean useLinuxNativeEpoll;
+    protected boolean useLinuxNativeIoUring;
 
     protected boolean allowCustomRequests = false;
 
@@ -73,7 +74,7 @@ public abstract class BasicConfiguration {
         setBossThreads(conf.getBossThreads());
         setWorkerThreads(conf.getWorkerThreads());
         setUseLinuxNativeEpoll(conf.isUseLinuxNativeEpoll());
-
+        setUseLinuxNativeIoUring(conf.isUseLinuxNativeIoUring());
         setPingInterval(conf.getPingInterval());
         setPingTimeout(conf.getPingTimeout());
         setFirstDataTimeout(conf.getFirstDataTimeout());
@@ -355,6 +356,14 @@ public abstract class BasicConfiguration {
 
     public void setUseLinuxNativeEpoll(boolean useLinuxNativeEpoll) {
         this.useLinuxNativeEpoll = useLinuxNativeEpoll;
+    }
+
+    public boolean isUseLinuxNativeIoUring() {
+        return useLinuxNativeIoUring;
+    }
+
+    public void setUseLinuxNativeIoUring(boolean useLinuxNativeIoUring) {
+        this.useLinuxNativeIoUring = useLinuxNativeIoUring;
     }
 
     /**

--- a/netty-socketio-core/src/main/java/module-info.java
+++ b/netty-socketio-core/src/main/java/module-info.java
@@ -30,4 +30,5 @@ module netty.socketio.core {
   requires io.netty.handler;
   requires io.netty.codec.http;
   requires org.slf4j;
+    requires io.netty.transport.classes.io_uring;
 }

--- a/netty-socketio-quarkus/netty-socketio-quarkus-runtime/src/main/java/com/corundumstudio/socketio/quarkus/config/NettySocketIOBasicConfigMapping.java
+++ b/netty-socketio-quarkus/netty-socketio-quarkus-runtime/src/main/java/com/corundumstudio/socketio/quarkus/config/NettySocketIOBasicConfigMapping.java
@@ -72,6 +72,9 @@ public interface NettySocketIOBasicConfigMapping {
     @WithDefault("false")
     boolean useLinuxNativeEpoll();
 
+    @WithDefault("false")
+    boolean useLinuxNativeIoUring();
+
     /**
      * Allow requests other than Engine.IO protocol
      * @see BasicConfiguration#isAllowCustomRequests()

--- a/netty-socketio-quarkus/netty-socketio-quarkus-runtime/src/main/java/com/corundumstudio/socketio/quarkus/recorder/NettySocketIOConfigRecorder.java
+++ b/netty-socketio-quarkus/netty-socketio-quarkus-runtime/src/main/java/com/corundumstudio/socketio/quarkus/recorder/NettySocketIOConfigRecorder.java
@@ -75,6 +75,7 @@ public class NettySocketIOConfigRecorder {
         configuration.setBossThreads(nettySocketIOBasicConfigMapping.bossThreads());
         configuration.setWorkerThreads(nettySocketIOBasicConfigMapping.workerThreads());
         configuration.setUseLinuxNativeEpoll(nettySocketIOBasicConfigMapping.useLinuxNativeEpoll());
+        configuration.setUseLinuxNativeIoUring(nettySocketIOBasicConfigMapping.useLinuxNativeIoUring());
         configuration.setAllowCustomRequests(nettySocketIOBasicConfigMapping.allowCustomRequests());
         configuration.setUpgradeTimeout(nettySocketIOBasicConfigMapping.upgradeTimeout());
         configuration.setPingTimeout(nettySocketIOBasicConfigMapping.pingTimeout());

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,12 @@
         <version>${netty.version}</version>
         <scope>provided</scope>
       </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-io_uring</artifactId>
+            <version>${netty.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Introduces configuration and dependency support for Netty's io_uring transport alongside epoll. Adds new config options, updates server initialization logic to prioritize io_uring if enabled, and updates Quarkus integration to support the new option.