### PR TITLE
Hazelcast version to 5.6.0 and module info updates

### DIFF
--- a/netty-socketio-core/pom.xml
+++ b/netty-socketio-core/pom.xml
@@ -76,7 +76,8 @@
     </dependency>
     <dependency>
       <groupId>com.hazelcast</groupId>
-      <artifactId>hazelcast-client</artifactId>
+      <artifactId>hazelcast</artifactId>
+        <version>5.6.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/netty-socketio-core/src/main/java/com/corundumstudio/socketio/store/HazelcastStore.java
+++ b/netty-socketio-core/src/main/java/com/corundumstudio/socketio/store/HazelcastStore.java
@@ -18,7 +18,7 @@ package com.corundumstudio.socketio.store;
 import java.util.UUID;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 
 
 public class HazelcastStore implements Store {

--- a/netty-socketio-core/src/main/java/module-info.java
+++ b/netty-socketio-core/src/main/java/module-info.java
@@ -18,8 +18,6 @@ module netty.socketio.core {
   requires com.fasterxml.jackson.databind;
 
   requires static com.hazelcast.core;
-  requires static com.hazelcast.client;
-
   requires static redisson;
 
   requires static io.netty.transport.classes.epoll;

--- a/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/CustomizedHazelcastContainer.java
+++ b/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/CustomizedHazelcastContainer.java
@@ -34,7 +34,7 @@ public class CustomizedHazelcastContainer extends GenericContainer<CustomizedHaz
      * Default constructor that initializes the Hazelcast container with the official Hazelcast image.
      */
     public CustomizedHazelcastContainer() {
-        super("hazelcast/hazelcast:3.12.12");
+        super("hazelcast/hazelcast:5.6.0");
     }
 
     @Override

--- a/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/HazelcastStoreFactoryTest.java
+++ b/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/HazelcastStoreFactoryTest.java
@@ -45,7 +45,7 @@ public class HazelcastStoreFactoryTest extends StoreFactoryTest {
         
         CustomizedHazelcastContainer customizedHazelcastContainer = (CustomizedHazelcastContainer) container;
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getGroupConfig().setName("dev").setPassword("dev-pass");
+        //clientConfig.getGroupConfig().setName("dev").setPassword("dev-pass");
         clientConfig.getNetworkConfig().addAddress(
             customizedHazelcastContainer.getHost() + ":" + customizedHazelcastContainer.getHazelcastPort()
         );

--- a/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/HazelcastStoreTest.java
+++ b/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/HazelcastStoreTest.java
@@ -43,7 +43,7 @@ public class HazelcastStoreTest extends AbstractStoreTest {
     protected Store createStore(UUID sessionId) throws Exception {
         CustomizedHazelcastContainer customizedHazelcastContainer = (CustomizedHazelcastContainer) container;
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getGroupConfig().setName("dev").setPassword("dev-pass");
+        //clientConfig.getGroupConfig().setName("dev").setPassword("dev-pass");
         clientConfig.getNetworkConfig().addAddress(
             customizedHazelcastContainer.getHost() + ":" + customizedHazelcastContainer.getHazelcastPort()
         );

--- a/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/pubsub/HazelcastPubSubStoreTest.java
+++ b/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/pubsub/HazelcastPubSubStoreTest.java
@@ -40,7 +40,7 @@ public class HazelcastPubSubStoreTest extends AbstractPubSubStoreTest {
     protected PubSubStore createPubSubStore(Long nodeId) throws Exception {
         CustomizedHazelcastContainer customizedHazelcastContainer = (CustomizedHazelcastContainer) container;
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getGroupConfig().setName("dev").setPassword("dev-pass");
+        //clientConfig.getGroupConfig().setName("dev").setPassword("dev-pass");
         clientConfig.getNetworkConfig().addAddress(
             customizedHazelcastContainer.getHost() + ":" + customizedHazelcastContainer.getHazelcastPort()
         );

--- a/netty-socketio-core/src/test/resources/hazelcast-test-config.xml
+++ b/netty-socketio-core/src/test/resources/hazelcast-test-config.xml
@@ -19,12 +19,9 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.6.xsd">
     
-    <group>
-        <name>dev</name>
-        <password>dev-pass</password>
-    </group>
+
     
     <network>
         <port>5701</port>


### PR DESCRIPTION
fixes issue #[37](https://github.com/NeatGuyCoding/netty-socketio/issues/37)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Hazelcast dependency to 5.6.0 and adjusted module transport requirements to be statically required.
* **Tests**
  * Updated test infrastructure and container image to match the new Hazelcast version and config schema.
  * Removed explicit group credentials from test configurations to rely on default/auth external settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->