### PR TITLE
Add Java 25 action

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,6 +21,7 @@ jobs:
         java-version:
           - 17
           - 21
+          - 25
     uses: ./.github/workflows/build.yml
     with:
       javaVersion: "${{ matrix.java-version }}"

--- a/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/HazelcastStoreFactoryTest.java
+++ b/netty-socketio-core/src/test/java/com/corundumstudio/socketio/store/HazelcastStoreFactoryTest.java
@@ -29,7 +29,7 @@ import com.corundumstudio.socketio.store.pubsub.PubSubStore;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
         <configuration>
           <argLine>
             -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
-            <!--For Java 25 support of byte-buddy. Byte-buddy is currently only used in mockito on unit tests within this project, so mitigate this problem by enable this property-->
+            <!--For Java 25 support of byte-buddy. Byte-buddy is currently only used in mockito on unit tests within this project, so mitigate this problem by enabling this property-->
             -Dnet.bytebuddy.experimental=true
             -javaagent:"${settings.localRepository}"/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar
             --add-opens netty.socketio/com.corundumstudio.socketio.store.pubsub=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <testcontainers.version>1.21.3</testcontainers.version>
     <netty.version>4.2.7.Final</netty.version>
     <jmockit.version>1.49</jmockit.version>
-    <byte-buddy.version>1.14.13</byte-buddy.version>
+    <byte-buddy.version>1.18.1</byte-buddy.version>
     <junit.version>5.10.1</junit.version>
     <junit-platform-launcher.version>1.10.1</junit-platform-launcher.version>
     <slf4j.version>2.0.16</slf4j.version>
@@ -528,6 +528,8 @@
         <configuration>
           <argLine>
             -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+            <!--For Java 25 support of byte-buddy. Byte-buddy is currently only used in mockito on unit tests within this project, so mitigate this problem by enable this property-->
+            -Dnet.bytebuddy.experimental=true
             -javaagent:"${settings.localRepository}"/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar
             --add-opens netty.socketio/com.corundumstudio.socketio.store.pubsub=ALL-UNNAMED
             --add-opens netty.socketio/com.corundumstudio.socketio.store=ALL-UNNAMED


### PR DESCRIPTION
Fix #39 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Byte Buddy dependency to version 1.18.1
  * Enabled experimental Java 25 support in the test framework

* **Tests**
  * Added Java 25 to the build matrix for expanded version coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->